### PR TITLE
Surface Firebase errors so Logan's silent failures become visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,18 +555,31 @@ const firebaseConfig = {
 const fbApp = initializeApp(firebaseConfig);
 const db    = getDatabase(fbApp);
 
+// Surface Firebase errors (otherwise rule rejections fail silently and
+// users see false "saved" toasts). Most likely cause of a failure here is
+// that the Realtime Database rules don't grant access to the path —
+// e.g. loganEvents / loganTasks need to be added alongside events / tasks.
+const reportFbError = (op, err) => {
+  console.error("Firebase " + op + " failed:", err);
+  const msg = op + " failed — " + ((err && err.message) || "check Firebase rules");
+  if (window.showToast) window.showToast(msg);
+};
+
 window.__db     = db;
 window.__ref    = ref;
-window.__set    = set;
-window.__remove = remove;
-window.__push   = push;
+window.__set    = (r, v) => { const p = set(r, v);    p.catch(e => reportFbError("Save", e));   return p; };
+window.__remove = (r)    => { const p = remove(r);    p.catch(e => reportFbError("Delete", e)); return p; };
+window.__push   = (r, v) => { const p = push(r, v);  p.catch(e => reportFbError("Save", e));   return p; };
 window.__get    = get;
 
-window.__listenCustody     = cb => onValue(ref(db, "custody"),       s => cb(s.val() || {}));
-window.__listenEvents      = cb => onValue(ref(db, "events"),        s => cb(s.val() || {}));
-window.__listenTasks       = cb => onValue(ref(db, "tasks"),         s => cb(s.val() || {}));
-window.__listenLoganEvents = cb => onValue(ref(db, "loganEvents"),   s => cb(s.val() || {}));
-window.__listenLoganTasks  = cb => onValue(ref(db, "loganTasks"),    s => cb(s.val() || {}));
+const listen = (path, cb, label) =>
+  onValue(ref(db, path), s => cb(s.val() || {}), err => reportFbError("Load " + label, err));
+
+window.__listenCustody     = cb => listen("custody",     cb, "custody");
+window.__listenEvents      = cb => listen("events",      cb, "Sadie's events");
+window.__listenTasks       = cb => listen("tasks",       cb, "Sadie's tasks");
+window.__listenLoganEvents = cb => listen("loganEvents", cb, "Logan's events");
+window.__listenLoganTasks  = cb => listen("loganTasks",  cb, "Logan's tasks");
 
 window.__hasPin = async (name) => { const s = await get(ref(db, "pins/" + name)); return s.exists(); };
 window.__getPin = async (name) => { const s = await get(ref(db, "pins/" + name)); return s.exists() ? s.val() : null; };


### PR DESCRIPTION
Logan's events and tasks routed through new top-level Realtime Database
keys (loganEvents / loganTasks) but no errors were ever surfaced — the
onValue listeners had no error callback, and __set/__push/__remove
didn't .catch(). If the database rules don't grant access to those
paths, reads returned nothing and writes failed silently behind a
"saved" toast.

Wrap the write helpers and the listener factory to log + toast on
rejection. The likely root cause still requires extending the Realtime
Database rules in the Firebase console to cover loganEvents and
loganTasks, but now any future rule mismatch will be visible instead
of silently swallowed.