### PR TITLE
Rename custody checkbox label to "switch off day"

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,7 +503,7 @@
         <div><label class="form-label" style="font-size:.65rem">To</label><input class="form-input" id="cust-to" type="date"></div>
       </div>
       <label class="cust-transition-row">
-        <input type="checkbox" id="cust-transition"> End date is the handoff/transition day
+        <input type="checkbox" id="cust-transition"> End date is the switch off day
       </label>
     </div>
     <!-- Switch off time -->


### PR DESCRIPTION
## Summary
- Updates the custody modal checkbox label from "End date is the handoff/transition day" to "End date is the switch off day" to match the new switch-off terminology

## Test plan
- [ ] Open a day on the calendar and tap the custody option
- [ ] Confirm the checkbox below the date range now reads "End date is the switch off day"

https://claude.ai/code/session_01L4WZJNWbQJJDMD8AZek2Po

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4WZJNWbQJJDMD8AZek2Po)_